### PR TITLE
Fix MongoDB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.js`. The page auto-updates
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+### Environment Variables
+
+Create a `.env.local` file in the project root and set `MONGODB_URI` to your MongoDB connection string:
+
+```bash
+MONGODB_URI="your-mongodb-uri"
+```
+
+Without this variable the gallery API routes will fail to connect to the database.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/lib/mongodb.js
+++ b/src/lib/mongodb.js
@@ -1,8 +1,11 @@
 import { MongoClient } from 'mongodb'
 
-const uri = process.env.MONGODB_URI || 'mongodb+srv://amir:YOUR_PASSWORD@grandpearl.qvl62it.mongodb.net/'
+const uri = process.env.MONGODB_URI
+
 if (!uri) {
-  throw new Error('Missing MONGODB_URI environment variable')
+  throw new Error(
+    'Missing MONGODB_URI environment variable. Set it in a .env.local file.'
+  )
 }
 
 let client


### PR DESCRIPTION
## Summary
- require `MONGODB_URI` instead of using placeholder credentials
- document environment variable setup in README

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685555e5eda4833291d4dbb48beead06