### PR TITLE
Add env example for MongoDB URI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGODB_URI="mongodb+srv://grandpearl.qvl62it.mongodb.net/"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- add `.env.example` with MongoDB URI placeholder
- allow committing example env file by updating `.gitignore`

## Testing
- `npm install`
- `CI=1 npm run lint` *(fails: next lint prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685558b9d9708332a0d00c72cc513a0e