### PR TITLE
Persist gallery uploads

### DIFF
--- a/src/app/api/gallery/route.js
+++ b/src/app/api/gallery/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import GalleryItem from '@/models/GalleryItem'
+import { connectToDatabase } from '@/lib/mongodb'
+
+export async function GET() {
+  try {
+    await connectToDatabase()
+    const items = await GalleryItem.find().sort({ createdAt: -1 })
+    return NextResponse.json(items)
+  } catch (error) {
+    console.error('Gallery GET error', error)
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json()
+    await connectToDatabase()
+    const itemsToCreate = Array.isArray(body.items) ? body.items : [body]
+    const created = await GalleryItem.insertMany(itemsToCreate)
+    return NextResponse.json({ success: true, items: created })
+  } catch (error) {
+    console.error('Gallery POST error', error)
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}

--- a/src/models/GalleryItem.js
+++ b/src/models/GalleryItem.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose'
+
+const GalleryItemSchema = new mongoose.Schema({
+  type: {
+    type: String,
+    enum: ['image', 'video'],
+    required: true
+  },
+  src: {
+    type: String,
+    required: true
+  },
+  title: String,
+  category: String,
+  description: String,
+  createdAt: {
+    type: Date,
+    default: Date.now
+  }
+})
+
+export default mongoose.models.GalleryItem || mongoose.model('GalleryItem', GalleryItemSchema)


### PR DESCRIPTION
## Summary
- create `GalleryItem` model for MongoDB
- add `/api/gallery` route with GET/POST handlers
- load gallery items from DB on gallery page
- upload gallery items to DB

## Testing
- `npm install`
- `npm run lint` *(fails: configuration prompt)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857f15fbaa08332a1bd69dfecb11d7a